### PR TITLE
WIP: show compressed and uncompressed stats

### DIFF
--- a/public/javascripts/main.js
+++ b/public/javascripts/main.js
@@ -1,69 +1,109 @@
 "use strict";
 (function() {
-    if (window.location.href.indexOf("error") === -1) {
-        var audiencesSize = document.getElementById("chart").getAttribute("data-audience");
-        var jQuerySize = document.getElementById("chart").getAttribute("data-jquery");
-        var experimentsSize = document.getElementById("chart").getAttribute("data-experiments");
-        var goalsSize = document.getElementById("chart").getAttribute("data-goals");
-        var optlyTotalSize = document.getElementById("chart").getAttribute("data-optlytotal");
-        var projectJSSize = document.getElementById("chart").getAttribute("data-projectjs");
-        var variationsSize = document.getElementById("chart").getAttribute("data-variations");
+    if (window.location.href.indexOf('analyze') !== -1 && window.location.href.indexOf("error") === -1) {
+        //var audiencesSize = document.getElementById("chart").getAttribute("data-audience");
+        //var jQuerySize = document.getElementById("chart").getAttribute("data-jquery");
+        //var experimentsSize = document.getElementById("chart").getAttribute("data-experiments");
+        //var goalsSize = document.getElementById("chart").getAttribute("data-goals");
+        //var optlyTotalSize = document.getElementById("chart").getAttribute("data-optlytotal");
+        //var projectJSSize = document.getElementById("chart").getAttribute("data-projectjs");
+        //var variationsSize = document.getElementById("chart").getAttribute("data-variations");
 
-        var total = audiencesSize + jQuerySize + experimentsSize + goalsSize + optlyTotalSize + projectJSSize
-        + variationsSize;
+        //var total = audiencesSize + jQuerySize + experimentsSize + goalsSize + optlyTotalSize + projectJSSize
+        //+ variationsSize;
+        var results = JSON.parse(resultsString);
+        var compressed = results.compressed;
+        var compressedBaseline = results.compressed.baseline;
+        delete results.compressed.baseline;
 
-        var data = [
-            {
-                value: optlyTotalSize,
-                color:"#0081ba",
-                highlight: "#005A82",
-                label: "Optimizely Logic"
-            },
-            {
-                value: jQuerySize,
-                color: "#9acce2",
-                highlight: "#8BB8CB",
-                label: "jQuery"
-            },
-            {
-                value: projectJSSize,
-                color: "#fd6b58",
-                highlight: "#CA5646",
-                label: "Project JS"
-            },
-            {
-                value: audiencesSize,
-                color:"#84cfca",
-                highlight: "#6AA6A2",
-                label: "Audiences"
-            },
-            {
-                value: experimentsSize,
-                color: "#FFCC00",
-                highlight: "#E6B800",
-                label: "Experiments"
-            },
-            {
-                value: variationsSize,
-                color: "#33CC33",
-                highlight: "#29A329",
-                label: "Variation Code"
-            },
-            {
-                value: goalsSize,
-                color: "#a3356e",
-                highlight: "#822A58",
-                label: "Goals"
-            }
-        ];
+        var uncompressed = results.uncompressed;
+        var uncompressedBaseline = results.uncompressed.baseline;
+        delete results.uncompressed.baseline;
+
+        var keys = Object.keys(results.compressed).sort();
+
+        var data = {
+            labels: keys,
+            datasets: [
+                {
+                    label: 'Compressed (gzip)',
+                    fillColor: "rgba(220,60,60,0.2)",
+                    strokeColor: "rgba(220,60,60,1)",
+                    pointColor: "rgba(220,60,60,1)",
+                    pointStrokeColor: "#fff",
+                    pointHighlightFill: "#fff",
+                    pointHighlightStroke: "rgba(220,60,60,1)",
+                    data: keys.map(function(key) {
+                        return results.compressed[key] / compressedBaseline * 100.0;
+                    })
+                },
+                {
+                    label: 'Uncompressed',
+                    fillColor: "rgba(151,187,205,0.2)",
+                    strokeColor: "rgba(151,187,205,1)",
+                    pointColor: "rgba(151,187,205,1)",
+                    pointStrokeColor: "#fff",
+                    pointHighlightFill: "#fff",
+                    pointHighlightStroke: "rgba(151,187,205,1)",
+                    data: keys.map(function(key) {
+                        return results.uncompressed[key] / uncompressedBaseline * 100.0;
+                    })
+                }
+            ]
+        };
+
+        //var uncompressedDataSet = [
+        //    {
+        //        value: optlyTotalSize,
+        //        color:"#0081ba",
+        //        highlight: "#005A82",
+        //        label: "Optimizely Logic"
+        //    },
+        //    {
+        //        value: jQuerySize,
+        //        color: "#9acce2",
+        //        highlight: "#8BB8CB",
+        //        label: "jQuery"
+        //    },
+        //    {
+        //        value: projectJSSize,
+        //        color: "#fd6b58",
+        //        highlight: "#CA5646",
+        //        label: "Project JS"
+        //    },
+        //    {
+        //        value: audiencesSize,
+        //        color:"#84cfca",
+        //        highlight: "#6AA6A2",
+        //        label: "Audiences"
+        //    },
+        //    {
+        //        value: experimentsSize,
+        //        color: "#FFCC00",
+        //        highlight: "#E6B800",
+        //        label: "Experiments"
+        //    },
+        //    {
+        //        value: variationsSize,
+        //        color: "#33CC33",
+        //        highlight: "#29A329",
+        //        label: "Variation Code"
+        //    },
+        //    {
+        //        value: goalsSize,
+        //        color: "#a3356e",
+        //        highlight: "#822A58",
+        //        label: "Goals"
+        //    }
+        //];
 
         var options = {
-            tooltipTemplate: "<%if (label){%><%=label%>: <%}%><%= numeral(circumference / 6.283).format('(0[.][00]%)') %>",
-            legendTemplate: "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<segments.length; i++){%><li class=\"legend-item\"><span class=\"swatch\" style=\"background-color:<%=segments[i].fillColor%>\"></span><h3 class=\"swatch-label\"><%if(segments[i].label){%><%=segments[i].label%><%}%></h2></li><%}%></ul>"
+            //tooltipTemplate: "<%if (label){%><%=label%>: <%}%><%= numeral(circumference / 6.283).format('(0[.][00]%)') %>",
+            legendTemplate : "<ul class=\"<%=name.toLowerCase()%>-legend\"><% for (var i=0; i<datasets.length; i++){%><li><span class=\"swatch\" style=\"background-color:<%=datasets[i].strokeColor%>\"></span><%if(datasets[i].label){%><%=datasets[i].label%><%}%></li><%}%></ul>"
         };
         var ctx = document.getElementById("chart").getContext("2d");
-        var myDoughnutChart = new Chart(ctx).Pie(data, options);
-        var legend = myDoughnutChart.generateLegend();
+        var myRadarChart = new Chart(ctx).Radar(data, options);
+        var legend = myRadarChart.generateLegend();
         $('.legend-container').append(legend);
     }
 

--- a/public/stylesheets/style.css
+++ b/public/stylesheets/style.css
@@ -74,7 +74,7 @@ body {
     padding: 0 10px;
 }
 
-.pie-legend {
+.pie-legend, .radar-legend {
 	display: inline-block;
 	list-style: none;
 	padding: 0px;

--- a/routes/index.js
+++ b/routes/index.js
@@ -28,7 +28,9 @@ router.post('/analyze', function(req, res) {
 	var project_id = req.body.project_id;
 	snippet(project_id, function(err, results) {
 		if (!err) {
-			res.render('analyze', { snippet : results });
+			res.render('analyze', {
+				results: JSON.stringify(results)
+			});
 		} else {
 			if (typeof results === "object") {
 				results = "internal_error";

--- a/services/snippet_analysis.js
+++ b/services/snippet_analysis.js
@@ -1,5 +1,20 @@
+var _ = require('lodash');
 var request = require('request');
 var async = require('async');
+var zlib = require('zlib');
+
+function computeWeight(snippet, from, to, callback) {
+	var replaced = snippet.replace(from, to);
+	zlib.deflate(replaced, function(err, buffer) {
+		if (err) {
+			return callback(err);
+		}
+		callback(null, {
+			uncompressed: replaced.length,
+			compressed: buffer.toString().length
+		});
+	});
+}
 
 module.exports = function (project_id, callback) {
 
@@ -27,99 +42,143 @@ module.exports = function (project_id, callback) {
 				var everythingAfterData = snippet.split('var DATA=')[1];
 				var experimentString = everythingAfterData.split('\n')[0].slice(0,-1);
 				var experimentData = JSON.parse(experimentString);
-				callback(null, snippet, experimentData);
+				callback(null, snippet, experimentString, experimentData);
 			} catch (error) {
 				callback(true, error);
 			}
 		},
 
-		function retrievejQuery (snippet, experimentData, callback) {
+		function retrievejQuery (snippet, dataString, experimentData, callback) {
 			try {
 				var firstHalfOfSnippet = snippet.split("var optimizelyCode")[0];
 				var secondHalfOfSnippet = snippet.split("var optimizelyCode")[1];
 				if (/optly\.Cleanse\.start\(\);/.test(firstHalfOfSnippet)) {
 					var jQuery = firstHalfOfSnippet.split("optly.Cleanse.start();")[1].trim();
-					callback(null, snippet, experimentData, jQuery);
+					callback(null, snippet, dataString, experimentData, jQuery);
 				} else {
 					var alternatejQuerySnippet = secondHalfOfSnippet.split("optly.Cleanse.start();")[1];
 					var jQuery = alternatejQuerySnippet.split("}(window);")[0].trim() + "}(window);";
-					callback(null, snippet, experimentData, jQuery);
+					callback(null, snippet, dataString, experimentData, jQuery);
 				}
 			} catch (error) {
 				callback(true, error);
 			}
 		},
 
-		function calculatejQuery (snippet, experimentData, jQuery, callback) {
+		function calculatejQuery (snippet, dataString, experimentData, jQuery, callback) {
 			var totals = {};
-			totals["jQuery"] = jQuery.length;
-			callback(null, snippet, experimentData, totals);
+			computeWeight(snippet, jQuery, '', function(err, result) {
+				if (err) {
+					return callback(true, err);
+				}
+				totals['jQuery'] = result;
+				callback(null, snippet, dataString, experimentData, totals);
+			});
 		},
 
-		function calculateProjectJS (snippet, experimentData, totals, callback) {
+		function calculateProjectJS (snippet, dataString, experimentData, totals, callback) {
 			if (experimentData.project_js === undefined) {
 				totals["projectJS"] = 0;
 			} else {
-				totals["projectJS"] = experimentData.project_js.length + "project_js".length;
+				computeWeight(snippet, experimentData.project_js, '', function(err, result) {
+					if (err) {
+						return callback(true, err);
+					}
+					totals['projectJS'] = result;
+					callback(null, snippet, dataString, experimentData, totals);
+				});
 			}
-			callback(null, snippet, experimentData, totals);
 		},
 
-		function calculateAudiences (snippet, experimentData, totals, callback) {
+		function calculateAudiences (snippet, dataString, experimentData, totals, callback) {
 			if (experimentData.audiences === undefined) {
 				totals["audiences"] = 0;
 			} else {
-				totals["audiences"] = JSON.stringify(experimentData.audiences).length + "audiences".length;
+				var withoutAudiences = _.omit(experimentData, 'audiences');
+				computeWeight(snippet, dataString, JSON.stringify(withoutAudiences), function(err, result) {
+					if (err) {
+						return callback(true, err);
+					}
+					totals['audiences'] = result;
+					callback(null, snippet, dataString, experimentData, totals);
+				});
 			}
-			callback(null, snippet, experimentData, totals);
 		},
 
-		function calculateExperiments (snippet, experimentData, totals, callback) {
+		function calculateExperiments (snippet, dataString, experimentData, totals, callback) {
 			if (experimentData.experiments === undefined) {
 				totals["experiments"] = 0;
 			} else {
-				totals["experiments"] = JSON.stringify(experimentData.experiments).length + "experiments".length;
+				var withoutExperiments = _.omit(experimentData, 'experiments');
+				computeWeight(snippet, dataString, JSON.stringify(withoutExperiments), function(err, result) {
+					if (err) {
+						return callback(true, err);
+					}
+					totals['experiments'] = result;
+					callback(null, snippet, dataString, experimentData, totals);
+				});
 			}
-			callback(null, snippet, experimentData, totals);
 		},
 
-		function calculateVariations (snippet, experimentData, totals, callback) {
-			if (experimentData.variations === undefined) {
+		function calculateVariations (snippet, dataString, experimentData, totals, callback) {
+			if (experimentData.variations === undefined && experimentData.sections === undefined) {
 				totals["variations"] = 0;
 			} else {
-				totals["variations"] = JSON.stringify(experimentData.variations).length + "variations".length;
+				var withoutVariations = _.omit(experimentData, ['variations', 'sections']);
+				computeWeight(snippet, dataString, JSON.stringify(withoutVariations), function(err, result) {
+					if (err) {
+						return callback(true, err);
+					}
+					totals['variations'] = result;
+					callback(null, snippet, dataString, experimentData, totals);
+				});
 			}
-			callback(null, snippet, experimentData, totals);
 		},
 
-		function calculateSections (snippet, experimentData, totals, callback) {
-			if (experimentData.sections === undefined) {
-				// Do nothing.
+		function calculateGoals (snippet, dataString, experimentData, totals, callback) {
+			if (experimentData.click_goals === undefined && experimentData.goalExpressions === undefined) {
+				totals['goals'] = 0;
 			} else {
-				totals["variations"] += JSON.stringify(experimentData.sections).length + "sections".length;
+				var withoutGoals = _.omit(experimentData, ['click_goals', 'goal_expressions']);
+				computeWeight(snippet, dataString, JSON.stringify(withoutGoals), function(err, result) {
+					if (err) {
+						return callback(true, err);
+					}
+					totals['goals'] = result;
+					callback(null, snippet, totals);
+				});
 			}
-			callback(null, snippet, experimentData, totals);
-		},
-
-		function calculateGoals (snippet, experimentData, totals, callback) {
-			if (experimentData.click_goals === undefined) {
-				var clickGoals = 0;
-			} else {
-				var clickGoals = JSON.stringify(experimentData.click_goals).length + "click_goals".length;
-			}
-			var goalExpressions = JSON.stringify(experimentData.goal_expressions).length + "goal_expressions".length;
-			totals["goals"] = goalExpressions + clickGoals;
 			callback(null, snippet, totals);
 		},
 
 		function calculateOptimizely (snippet, totals, callback) {
-			var snippetSize = snippet.length;
-			var overHead = 0;
-			for (var index in totals) {
-  				overHead += totals[index];
-			}
-			totals["optlyTotal"] = snippetSize - overHead;
-			callback(null, totals);
+			computeWeight(snippet, '', '', function(err, result) {
+				if (err) {
+					return callback(true, err);
+				}
+				var baseline = result;
+				console.log('baseline', baseline);
+
+				var uncompressed = {'baseline': baseline.uncompressed};
+				var compressed = {'baseline': baseline.compressed};
+
+				var uncompressedTotal = 0;
+				// TODO: this is kind of a lie since compression is nonlinear
+				var compressedTotal = 0;
+				_.forEach(totals, function(keyResult, key) {
+					//uncompressedTotal += (baseline.uncompressed - keyResult.uncompressed);
+					//compressedTotal += baseline.compressed - keyResult.compressed;
+					uncompressed[key] = (baseline.uncompressed - keyResult.uncompressed);// / baseline.uncompressed;
+					compressed[key] = (baseline.compressed - keyResult.compressed);// / baseline.compressed;
+				});
+
+				console.log('compressed', compressed);
+				console.log('uncompressed', uncompressed);
+				callback(null, {
+					compressed: compressed,
+					uncompressed: uncompressed
+				});
+			});
 		}
 		],
 	function (err, results) {

--- a/views/analyze.hbs
+++ b/views/analyze.hbs
@@ -20,7 +20,7 @@
 	</div>
 
 	<div class="col-md-6">
-		<canvas id="chart" data-audience="{{ snippet.audiences }}" data-jQuery="{{ snippet.jQuery }}" data-experiments="{{ snippet.experiments }}" data-goals="{{ snippet.goals }}" data-optlyTotal="{{ snippet.optlyTotal }}" data-projectJS="{{ snippet.projectJS }}" data-variations="{{ snippet.variations }}"></canvas>
+		<canvas id="chart"></canvas>
 		<div id="secret">
 			<form class="form-group" method="POST" action="/analyze">
 				<label class="field">Project ID</label></br>
@@ -33,3 +33,6 @@
 		Visualization created using <a href="http://www.chartjs.org/">Chart.js</a> library.
 	</footer>
 </div>
+<script>
+  var resultsString = '{{{ results }}}';
+</script>


### PR DESCRIPTION
In order to compute the impact of specific data on the compressed payload, it's not sufficient to look at the % of the uncompressed snippet taken up by that data, because the size of the compressed payload does not scale linearly with the data. Update the "analyze" service to generate estimates for gzip-payload impact as well, by removing each piece of data and recompressing the whole.

Similarly, for gzip, a pie chart isn't accurate because the "parts" don't really add up to the whole (due to the nonlinearity), so switch to a "radar" chart of the % of baseline payload size reduced by removing each piece of data.

Still WIP, many things are very messy!

@Bigspencey 
